### PR TITLE
Removed customer gateway from vpc module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -344,23 +344,13 @@ resource "aws_s3_bucket" "this" {
   }
 }
 
-################################################
-# Customer gateway for creating a VPN connection
-################################################
-resource "aws_customer_gateway" "this" {
-  count      = "${var.enable_customer_gateway ? 1 : 0}"
-  bgp_asn    = "${var.bgp_asn}"
-  ip_address = "${var.site_public_ip}"
-  type       = "ipsec.1"
-}
-
 ################
 # VPN connection
 ################
 resource "aws_vpn_connection" "this" {
   count               = "${var.enable_vpn_connection ? 1 : 0}"
   vpn_gateway_id      = "${aws_vpn_gateway.this.id}"
-  customer_gateway_id = "${var.enable_customer_gateway ? aws_customer_gateway.this.id : var.custom_customer_gateway}"
+  customer_gateway_id = "${var.customer_gateway}"
   type                = "ipsec.1"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -112,12 +112,7 @@ variable "enable_vpn_gateway" {
   default     = false
 }
 
-variable "enable_customer_gateway" {
-  description = "Should be true if you want to create a new Customer Gateway resource and attach it to the VPC"
-  default     = false
-}
-
-variable "custom_customer_gateway" {
+variable "customer_gateway" {
   description = "Should be a valid customer gateway ID"
   default     = ""
 }
@@ -255,16 +250,6 @@ variable "enable_s3_bucket" {
 variable "bucket_name" {
   description = "Name of bucket that will be created with the VPC"
   default     = ""
-}
-
-variable "site_public_ip" {
-  description = "Should be your location public ip"
-  default     = ""
-}
-
-variable "bgp_asn" {
-  description = "BGP autonomous system number"
-  default     = "65000"
 }
 
 variable "enable_vpn_route_private_propagation" {


### PR DESCRIPTION
In order to reference the same customer gateway from several VPNs in the same VPC, we need to define them outside the VPC creation.