### PR TITLE
Remove vpn creation from module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -298,17 +298,6 @@ resource "aws_route_table_association" "public" {
   route_table_id = "${aws_route_table.public.id}"
 }
 
-##############
-# VPN Gateway
-##############
-resource "aws_vpn_gateway" "this" {
-  count = "${var.enable_vpn_gateway ? 1 : 0}"
-
-  vpc_id = "${aws_vpc.this.id}"
-
-  tags = "${merge(var.tags, map("Name", format("%s", var.name)))}"
-}
-
 ######################################
 # Peering Connections to another VPCs
 ######################################
@@ -342,32 +331,4 @@ resource "aws_s3_bucket" "this" {
   versioning {
     enabled = true
   }
-}
-
-################
-# VPN connection
-################
-resource "aws_vpn_connection" "this" {
-  count               = "${var.enable_vpn_connection ? 1 : 0}"
-  vpn_gateway_id      = "${aws_vpn_gateway.this.id}"
-  customer_gateway_id = "${var.customer_gateway}"
-  type                = "ipsec.1"
-}
-
-###############################
-# VPN private route propagation
-###############################
-resource "aws_vpn_gateway_route_propagation" "private" {
-  count          = "${var.enable_vpn_route_private_propagation ? max(length(var.private_subnets), length(var.backend_subnets)) : 0}"
-  vpn_gateway_id = "${aws_vpn_gateway.this.id}"
-  route_table_id = "${element(aws_route_table.private.*.id, count.index)}"
-}
-
-##############################
-# VPN public route propagation
-##############################
-resource "aws_vpn_gateway_route_propagation" "public" {
-  count          = "${var.enable_vpn_route_public_propagation ? length(var.public_subnets) : 0}"
-  vpn_gateway_id = "${aws_vpn_gateway.this.id}"
-  route_table_id = "${aws_route_table.public.id}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -138,12 +138,6 @@ output "vpc_endpoint_dynamodb_id" {
   value       = "${element(concat(aws_vpc_endpoint.dynamodb.*.id, list("")), 0)}"
 }
 
-# VPN Gateway
-output "vgw_id" {
-  description = "The ID of the VPN Gateway"
-  value       = "${element(concat(aws_vpn_gateway.this.*.id, list("")), 0)}"
-}
-
 output "vpc_endpoint_dynamodb_pl_id" {
   description = "The prefix list for the DynamoDB VPC endpoint."
   value       = "${element(concat(aws_vpc_endpoint.dynamodb.*.prefix_list_id, list("")), 0)}"

--- a/variables.tf
+++ b/variables.tf
@@ -107,21 +107,6 @@ variable "map_public_ip_on_launch" {
   default     = true
 }
 
-variable "enable_vpn_gateway" {
-  description = "Should be true if you want to create a new VPN Gateway resource and attach it to the VPC"
-  default     = false
-}
-
-variable "customer_gateway" {
-  description = "Should be a valid customer gateway ID"
-  default     = ""
-}
-
-variable "enable_vpn_connection" {
-  description = "Should be true if you want to create a new VPN connection against a customer gateway"
-  default     = false
-}
-
 variable "private_propagating_vgws" {
   description = "A list of VGWs the private route table should propagate"
   default     = []
@@ -250,14 +235,4 @@ variable "enable_s3_bucket" {
 variable "bucket_name" {
   description = "Name of bucket that will be created with the VPC"
   default     = ""
-}
-
-variable "enable_vpn_route_private_propagation" {
-  description = "Should be true if you need to propagate your private route tables to your VPN connection"
-  default     = false
-}
-
-variable "enable_vpn_route_public_propagation" {
-  description = "Should be true if you need to propagate your public route tables to your VPN connection"
-  default     = false
 }


### PR DESCRIPTION
We need the posibility to create more than one VPN per VPC, for example:

GBL -> Libertador 16
GBL -> Libertador 2

In order to do that, we need to extract the VPN code outside the VPN itself